### PR TITLE
Improve Trust section style

### DIFF
--- a/components/sections/TrustSection.js
+++ b/components/sections/TrustSection.js
@@ -36,7 +36,7 @@ export default function TrustSection() {
 
   return (
     <section id="trust" className={styles.trustSection}>
-    <h1 className={styles.title}>Confían en nosotros</h1>
+      <h1>Confían en nosotros</h1>
       <div className={styles.carouselWrapper}>
         <button
           className={`${styles.carouselButton} ${styles.carouselButtonLeft}`}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -75,12 +75,16 @@
   align-items: center;
 }
 
+.trustSection h1 {
+  font-size: 2.5rem;
+  margin-bottom: 2rem;
+}
+
 /* Carrusel de patrocinadores */
 .carouselWrapper {
   position: relative;
   overflow: hidden;
   width: 100%;
-  max-width: 1200px;
 }
 
 .carouselTrack {
@@ -97,7 +101,8 @@
 }
 
 .sponsorLink {
-  flex: 0 0 auto;
+  flex: 0 0 25%;
+  max-width: 25%;
   background: #ffffff;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -110,7 +115,7 @@
 }
 
 .sponsorLogo {
-  height: 60px;
+  height: 80px;
   width: auto;
   display: block;
 }


### PR DESCRIPTION
## Summary
- tweak Trust section header style
- make sponsor carousel full width
- enlarge sponsor cards

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68629b1fef608321a3fb0d12fc6c0c35