### PR TITLE
Add interactive Products section

### DIFF
--- a/components/FloatingProductDetail.js
+++ b/components/FloatingProductDetail.js
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import styles from '../styles/Home.module.css';
+
+export default function FloatingProductDetail({ product, onClose }) {
+  useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  if (!product) return null;
+
+  return (
+    <div className={styles.productModalOverlay} onClick={onClose}>
+      <div
+        className={styles.productModal}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className={styles.modalClose}
+          onClick={onClose}
+          aria-label="Cerrar"
+        >
+          &times;
+        </button>
+        <h2>{product.title}</h2>
+        <p>{product.long}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/ProductsSection.js
+++ b/components/sections/ProductsSection.js
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import styles from '../../styles/Home.module.css';
+import FloatingProductDetail from '../FloatingProductDetail';
+
+const products = [
+  {
+    id: 'gen',
+    title: 'Generador de contenido',
+    short: 'Crea ejercicios, res\u00famenes y ex\u00e1menes al instante.',
+    long:
+      'SophIA genera materiales did\u00e1cticos como test, flashcards, res\u00famenes y modelos de examen de forma autom\u00e1tica.',
+    image: '/img/gen-content.jpg',
+  },
+  {
+    id: 'interactive',
+    title: 'Entornos interactivos',
+    short: 'Simula clases activas con rol, gamificaci\u00f3n o proyectos.',
+    long:
+      'Implementa din\u00e1micas de roleplay, proyectos o gamificaci\u00f3n que el docente puede configurar seg\u00fan sus objetivos.',
+    image: '/img/interactive.jpg',
+  },
+  {
+    id: 'auto',
+    title: 'Correcci\u00f3n autom\u00e1tica',
+    short: 'Eval\u00faa tareas y tests seg\u00fan tus propios criterios.',
+    long:
+      'Define criterios de evaluaci\u00f3n y deja que SophIA corrija actividades de forma autom\u00e1tica y revisable.',
+    image: '/img/auto-correct.jpg',
+  },
+];
+
+export default function ProductsSection() {
+  const [active, setActive] = useState(null);
+
+  return (
+    <section id="products" className={`${styles.section} ${styles.products}`}>
+      {active && (
+        <FloatingProductDetail product={active} onClose={() => setActive(null)} />
+      )}
+      <div className={styles.productGrid}>
+        {products.map((p) => (
+          <div
+            key={p.id}
+            className={styles.productCard}
+            style={{ backgroundImage: `url(${p.image})` }}
+          >
+            <button
+              className={styles.productButton}
+              onClick={() => setActive(p)}
+              aria-label={`M\u00e1s informaci\u00f3n sobre ${p.title}`}
+            >
+              +
+            </button>
+            <h3>{p.title}</h3>
+            <p>{p.short}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
 import HomeSection from '../components/sections/HomeSection';
+import ProductsSection from '../components/sections/ProductsSection';
 import AboutSection from '../components/sections/AboutSection';
 import TrustSection from '../components/sections/TrustSection';
 import ContactSection from '../components/sections/ContactSection';
@@ -26,6 +27,7 @@ export default function Home() {
           </div>
         </nav>
         <HomeSection />
+        <ProductsSection />
         <AboutSection />
         <TrustSection />
         <ContactSection />

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -331,3 +331,127 @@
 .calendlyContainer iframe::-webkit-scrollbar {
   display: none; /* Chrome, Safari */
 }
+
+/* Products Section */
+.products {
+  background: #faf6e8;
+  font-size: 1rem;
+  padding: 4rem 1rem;
+}
+
+.productGrid {
+  display: flex;
+  gap: 2rem;
+  width: 100%;
+  max-width: 1200px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.productCard {
+  position: relative;
+  flex: 1 1 300px;
+  height: 300px;
+  color: #ffffff;
+  border-radius: 8px;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1rem;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.productCard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.productCard h3,
+.productCard p {
+  margin: 0;
+  z-index: 1;
+  text-align: left;
+}
+
+.productCard p {
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.productCard:hover {
+  transform: scale(1.05);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.productButton {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.8);
+  color: #130000;
+  z-index: 1;
+  transition: background 0.2s ease;
+}
+
+.productButton:hover {
+  background: #ffffff;
+}
+
+@media (max-width: 768px) {
+  .productCard {
+    flex: 1 1 100%;
+  }
+}
+
+.productModalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.3s ease forwards;
+  z-index: 200;
+}
+
+.productModal {
+  background: #faf6e8;
+  color: #130000;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 90%;
+  position: relative;
+  animation: slideIn 0.3s ease forwards;
+}
+
+.modalClose {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideIn {
+  from { transform: translateY(-20px); }
+  to { transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- create `ProductsSection` with three product cards and modal support
- add `FloatingProductDetail` for fullscreen modal behavior
- update landing page to include products section
- style new section, cards, and modal
- remove placeholder images and assume existing assets
- add newline at end of stylesheet

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863074b11cc8321a17802723df2b286